### PR TITLE
mailers: email switchover

### DIFF
--- a/app/mailers/sub_request_mailer.rb
+++ b/app/mailers/sub_request_mailer.rb
@@ -18,7 +18,7 @@ class SubRequestMailer < ApplicationMailer
     @sub_request = sub_request
     @dj = @sub_request.episode.dj
 
-    mail to: 'Radio Free Ann Arbor <rfaa-mod@umich.edu>',
+    mail to: 'Radio Free Ann Arbor <wcbn-announce@umich.edu>',
          subject: "#{@sub_request.episode.dj} needs a sub #{@sub_request.for}!"
   end
 


### PR DESCRIPTION
This PR changes the sub board email from rfaa-mod at umich to wcbn-announce at umich